### PR TITLE
feat: service key 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.11'
-	id 'io.spring.dependency-management' version '1.1.0'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.11'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'com.data'
@@ -9,22 +9,23 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '8'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/data/jejuData/config/ApiProperties.java
+++ b/src/main/java/com/data/jejuData/config/ApiProperties.java
@@ -1,0 +1,15 @@
+package com.data.jejuData.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "service")
+public class ApiProperties {
+    private String key;
+
+}

--- a/src/main/java/com/data/jejuData/controller/DataController.java
+++ b/src/main/java/com/data/jejuData/controller/DataController.java
@@ -19,7 +19,7 @@ import java.net.URISyntaxException;
 @RestController
 @RequestMapping("/api")
 public class DataController {
-    Logger logger = LoggerFactory.getLogger(DataController.class);
+    private static final Logger logger = LoggerFactory.getLogger(DataController.class);
 
     DataService dataService;
 

--- a/src/main/java/com/data/jejuData/dto/DataDto.java
+++ b/src/main/java/com/data/jejuData/dto/DataDto.java
@@ -10,9 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 @NoArgsConstructor
 public class DataDto {
 
-    @Value("${service.key}")
-    String serviceKey;
-
     String pageNo;
 
     String numOfRows;

--- a/src/main/java/com/data/jejuData/service/impl/DataServiceImpl.java
+++ b/src/main/java/com/data/jejuData/service/impl/DataServiceImpl.java
@@ -1,19 +1,20 @@
 package com.data.jejuData.service.impl;
 
+import com.data.jejuData.config.ApiProperties;
 import com.data.jejuData.dto.DataDto;
 import com.data.jejuData.service.DataService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.*;
 
 @Service
 public class DataServiceImpl implements DataService {
-    Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(DataService.class);
+
+    private final ApiProperties properties;
 
     private static final String GET_AUTO_KIOSK_URI = "https://apis.data.go.kr/6510000/autoKioskService/getAutoKioskList";
     private static final String GET = "GET";
@@ -21,11 +22,15 @@ public class DataServiceImpl implements DataService {
     private static final String APPLICATION_JSON = "application/json";
     private static final String UTF_8 = "UTF-8";
 
+    public DataServiceImpl(ApiProperties properties) {
+        this.properties = properties;
+    }
+
     @Override
     public HttpURLConnection getAutoKioskService(DataDto dataDto) throws IOException {
 
         StringBuilder uriBuilder = new StringBuilder(GET_AUTO_KIOSK_URI);
-        uriBuilder.append("?" + URLEncoder.encode("serviceKey",UTF_8) + "=" + URLEncoder.encode(dataDto.getServiceKey(),UTF_8));
+        uriBuilder.append("?" + URLEncoder.encode("serviceKey",UTF_8) + "=" + URLEncoder.encode(properties.getKey(),UTF_8));
         uriBuilder.append("&" + URLEncoder.encode("pageNo",UTF_8) + "=" + URLEncoder.encode(dataDto.getPageNo(),UTF_8));
         uriBuilder.append("&" + URLEncoder.encode("numOfRows",UTF_8) + "=" + URLEncoder.encode(dataDto.getNumOfRows(),UTF_8));
         uriBuilder.append("&" + URLEncoder.encode("instlPlaceNm",UTF_8) + "=" + URLEncoder.encode(dataDto.getInstlPlaceNm(),UTF_8));


### PR DESCRIPTION
DataDto에서 관리하던
[업무용 데이터 / pageNo, numOfRows, instlPlaceNm], [외부통신용 설정값 / serviceKey]
에서 serviceKey를 관리하는 별도의 설정용 객체를 추가하였습니다.

보통 업무용 데이터의 경우 변경이 되지만, 서비스 이용에 필요한 설정값은 특이한 경우가 없으면 유지하기 때문에

관리를 분리하였습니다.

참고 부탁드립니다~